### PR TITLE
Fixed Chrome Builds

### DIFF
--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -7,8 +7,6 @@
 
     <!-- Customize the manifest options -->
     <meta name="manifest.open_in_tab" content="true" />
-    <meta name="manifest.chrome_style" content="true" />
-    <meta name="manifest.browser_style" content="true" />
 
     <!-- Set include/exclude if the page should be removed from some builds -->
     <!-- <meta name="manifest.include" content="['chrome', 'firefox']" /> -->


### PR DESCRIPTION
When building for chromium based browsers a deprecated configuration was being used that would cause chromium based browsers not to load the extension